### PR TITLE
Improved delay mechanism using `random.uniform`

### DIFF
--- a/finnish_media_scrapers/scripts/fetch_hs.py
+++ b/finnish_media_scrapers/scripts/fetch_hs.py
@@ -67,7 +67,7 @@ async def _amain():
                             article_file.write(
                                 "<!DOCTYPE html><head><meta charset='utf-8'></head>" + article + "</html>")
                         logging.info("Wrote article %s into %s", url, file)
-                        sleep(random.uniform(0,args.delay*2))
+                        sleep(random.uniform(0, args.delay*2))
                     else:
                         logging.info("Skipping %s as %s already exists.", url, file)
         finally:

--- a/finnish_media_scrapers/scripts/fetch_hs.py
+++ b/finnish_media_scrapers/scripts/fetch_hs.py
@@ -67,7 +67,7 @@ async def _amain():
                             article_file.write(
                                 "<!DOCTYPE html><head><meta charset='utf-8'></head>" + article + "</html>")
                         logging.info("Wrote article %s into %s", url, file)
-                        sleep(random.randrange(args.delay*2))
+                        sleep(random.uniform(0,args.delay*2))
                     else:
                         logging.info("Skipping %s as %s already exists.", url, file)
         finally:

--- a/finnish_media_scrapers/scripts/fetch_open.py
+++ b/finnish_media_scrapers/scripts/fetch_open.py
@@ -44,7 +44,7 @@ async def _amain():
                         with open(article_file_name, "w", encoding="utf-8") as article_file:
                             article_file.write(content)
                     logging.info("wrote %s into %s", article['url'], article_file_name)
-                    sleep(random.randrange(args.delay*2))
+                    sleep(random.uniform(0,args.delay*2))
 
 
 def main():

--- a/finnish_media_scrapers/scripts/fetch_open.py
+++ b/finnish_media_scrapers/scripts/fetch_open.py
@@ -44,7 +44,7 @@ async def _amain():
                         with open(article_file_name, "w", encoding="utf-8") as article_file:
                             article_file.write(content)
                     logging.info("wrote %s into %s", article['url'], article_file_name)
-                    sleep(random.uniform(0,args.delay*2))
+                    sleep(random.uniform(0, args.delay*2))
 
 
 def main():

--- a/finnish_media_scrapers/scripts/query_hs.py
+++ b/finnish_media_scrapers/scripts/query_hs.py
@@ -55,7 +55,7 @@ async def _amain():
                 for article in response.articles:
                     csv_output.writerow([article.id, article.url,
                                         article.title, article.date_modified])
-                sleep(random.randrange(args.delay*2))
+                sleep(random.uniform(0,args.delay*2))
             logging.info("Processed %s articles in total.", total_count)
 
 

--- a/finnish_media_scrapers/scripts/query_hs.py
+++ b/finnish_media_scrapers/scripts/query_hs.py
@@ -55,7 +55,7 @@ async def _amain():
                 for article in response.articles:
                     csv_output.writerow([article.id, article.url,
                                         article.title, article.date_modified])
-                sleep(random.uniform(0,args.delay*2))
+                sleep(random.uniform(0, args.delay*2))
             logging.info("Processed %s articles in total.", total_count)
 
 

--- a/finnish_media_scrapers/scripts/query_il.py
+++ b/finnish_media_scrapers/scripts/query_il.py
@@ -55,7 +55,7 @@ async def _amain():
                 for article in response.articles:
                     csv_output.writerow([article.id, article.url,
                                         article.title, article.date_modified])
-                sleep(random.uniform(0,args.delay*2))
+                sleep(random.uniform(0, args.delay*2))
         logging.info("Processed %s articles in total.", total_count)
 
 

--- a/finnish_media_scrapers/scripts/query_il.py
+++ b/finnish_media_scrapers/scripts/query_il.py
@@ -55,7 +55,7 @@ async def _amain():
                 for article in response.articles:
                     csv_output.writerow([article.id, article.url,
                                         article.title, article.date_modified])
-                sleep(random.randrange(args.delay*2))
+                sleep(random.uniform(0,args.delay*2))
         logging.info("Processed %s articles in total.", total_count)
 
 

--- a/finnish_media_scrapers/scripts/query_is.py
+++ b/finnish_media_scrapers/scripts/query_is.py
@@ -56,7 +56,7 @@ async def _amain():
                 for article in response.articles:
                     csv_output.writerow([article.id, article.url,
                                         article.title, article.date_modified])
-                sleep(random.randrange(args.delay*2))
+                sleep(random.uniform(0,args.delay*2))
         logging.info("Processed %s articles in total.", total_count)
 
 

--- a/finnish_media_scrapers/scripts/query_is.py
+++ b/finnish_media_scrapers/scripts/query_is.py
@@ -56,7 +56,7 @@ async def _amain():
                 for article in response.articles:
                     csv_output.writerow([article.id, article.url,
                                         article.title, article.date_modified])
-                sleep(random.uniform(0,args.delay*2))
+                sleep(random.uniform(0, args.delay*2))
         logging.info("Processed %s articles in total.", total_count)
 
 

--- a/finnish_media_scrapers/scripts/query_yle.py
+++ b/finnish_media_scrapers/scripts/query_yle.py
@@ -56,7 +56,7 @@ async def _amain():
                 for article in response.articles:
                     csv_output.writerow([article.id, article.url,
                                         article.title, article.date_modified])
-                sleep(random.randrange(args.delay*2))
+                sleep(random.uniform(0,args.delay*2))
         logging.info("Processed %s articles in total.", total_count)
 
 

--- a/finnish_media_scrapers/scripts/query_yle.py
+++ b/finnish_media_scrapers/scripts/query_yle.py
@@ -56,7 +56,7 @@ async def _amain():
                 for article in response.articles:
                     csv_output.writerow([article.id, article.url,
                                         article.title, article.date_modified])
-                sleep(random.uniform(0,args.delay*2))
+                sleep(random.uniform(0, args.delay*2))
         logging.info("Processed %s articles in total.", total_count)
 
 


### PR DESCRIPTION
This pull request includes changes to six script files in finnish_media_scrapers to improve the delay mechanism by using a uniform distribution (`random.uniform`) for the sleep intervals. The change addresses the error caused by the previously used `random.randrange`, which does not accept floats as arguments. The change also ensures delays of intended duration are achieved (see discussion in issue #21).

### Details
Replaced `sleep(random.randrange(args.delay*2))` with `sleep(random.uniform(0,args.delay*2))` to allow float values for sleep intervals.

### Testing
Tested by temporarily adding a `time.time` timer to verify sleep duration varies as expected: the delay is between 0.0 and 2.0 with the default value of 1.0 for delay.